### PR TITLE
refactor: dnsmasq

### DIFF
--- a/stuff.sh
+++ b/stuff.sh
@@ -84,7 +84,7 @@ add_dns_record() {
     local domain="$1"
     local ip="$2"
 
-    # Use dnsmasq for proper Pi-hole resolution
+    # Now uses dnsmasq
     touch "$DNSMASQ_CONF"
 
     if grep -q "address=/$domain/" "$DNSMASQ_CONF" 2>/dev/null; then


### PR DESCRIPTION
Turns out, I've been doing it wrong. Pihole uses dnsmasq as its resolver, so `/etc/hosts` wasn't an effective approach.